### PR TITLE
Improve update

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -180,9 +180,10 @@ fresh_install_with_latest_binary() {
 fresh_update() {
   find $FRESH_PATH/source -type d -name '.git' | sort | while read DIR; do
     local DIR="$(dirname "$DIR")"
-    echo "Updating $(_repo_name_from_source_path "$DIR")"
+    echo "* Updating $(_repo_name_from_source_path "$DIR")"
     cd "$DIR"
-    git pull --rebase
+    git pull --rebase 2>&1 | sed 's/^/| /'
+    [ "${PIPESTATUS[0]}" -eq 0 ] || exit 1
     cd - > /dev/null
   done
 }

--- a/test/fresh_test.sh
+++ b/test/fresh_test.sh
@@ -301,6 +301,17 @@ git pull --rebase
 EOF
 }
 
+it_shows_progress_when_updating() {
+  mkdir -p $FRESH_PATH/source/repo/name/.git
+  mkdir -p $FRESH_PATH/source/other_repo/other_name/.git
+  stubGit
+
+  bin/fresh update > "$SANDBOX_PATH/fresh_out.log" 2> "$SANDBOX_PATH/fresh_err.log"
+  assertTrue 'successfully updates' $?
+  assertTrue 'outputs "repo/name"' 'grep -qxF "* Updating repo/name" $SANDBOX_PATH/fresh_out.log'
+  assertTrue 'shows git output with prefix' 'grep -qxF "| stub git output" $SANDBOX_PATH/fresh_out.log'
+}
+
 it_does_not_run_build_if_update_fails() {
   echo fresh aliases >> $FRESH_RCFILE
   mkdir -p $FRESH_LOCAL

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -41,6 +41,7 @@ runFresh() {
 stubGit() {
   cat > $SANDBOX_PATH/bin/git <<EOF
 #!/bin/bash -e
+echo stub git output
 echo cd "\$(pwd)" >> $SANDBOX_PATH/git.log
 echo git "\$@" >> $SANDBOX_PATH/git.log
 case "\$1" in


### PR DESCRIPTION
Output is now:

```
Updating fresh/freshshell
First, rewinding head to replay your work on top of it...
Fast-forwarded master to 42b7929a0c7d27c99439c71c459fe85e29a38c54.
Updating dotfiles/jasoncodes
Current branch master is up to date.
Updating oh-my-zsh/robbyrussell
Current branch master is up to date.
# ...
Your dot files are now fresh.
```

I'm open to suggestions of better wording. I was thinking maybe an `*` before each `Updating` line.

I also fixed an issue where "Your dot files are now fresh." would show up twice on `fresh update`.
