### PR TITLE
Allow whole config directories under ~ 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -105,6 +105,14 @@ fresh twe4ked/dotfiles 'vim/*' --file=~/.vimrc --marker='"'
 fresh jasoncodes/dotfiles config/pryrc --file --marker
 ```
 
+#### Sourcing whole directories of files
+
+Whole directories can be built and symlinked by including a trailing slash on the `--file` path:
+
+``` sh
+fresh mutt --file=~/.mutt/
+```
+
 #### Building files without symlinking
 
 Some tools/libraries (e.g. zsh plugins) require specific directory structures.

--- a/bin/fresh
+++ b/bin/fresh
@@ -186,9 +186,16 @@ _fresh_file() {
         else
           local base_path="$SOURCE_DIR/$FILE_NAME/"
         fi
-        DEST_NAME="$MODE_ARG${SOURCE_FILE#$base_path}"
-        SYMLINK_SOURCE=""
-        SYMLINK_PATH=""
+        if echo "$MODE_ARG" | grep -q '^[~/]'; then
+          local dest_dir="$(basename "$MODE_ARG" | sed 's/^\.//')"
+          DEST_NAME="$dest_dir/${SOURCE_FILE#$base_path}"
+          SYMLINK_SOURCE="$dest_dir"
+          SYMLINK_PATH="${MODE_ARG/%\//}"
+        else
+          DEST_NAME="$MODE_ARG${SOURCE_FILE#$base_path}"
+          SYMLINK_SOURCE=""
+          SYMLINK_PATH=""
+        fi
       elif echo "$MODE_ARG" | grep -q '^[~/]'; then
         DEST_NAME="$(basename "$MODE_ARG" | sed 's/^\.//')"
         SYMLINK_SOURCE="$DEST_NAME"

--- a/test/fresh_test.sh
+++ b/test/fresh_test.sh
@@ -397,6 +397,31 @@ vendor/test/foo
 EOF
 }
 
+it_links_directories_of_generic_files() {
+  echo 'fresh foo --file=~/.foo/' >> $FRESH_RCFILE
+  echo 'fresh foo/bar --file=~/.other/' >> $FRESH_RCFILE
+
+  mkdir -p $FRESH_LOCAL/{foo/bar,foobar}
+  touch $FRESH_LOCAL/foo/bar/file{1,2}
+  touch $FRESH_LOCAL/foo/file3
+  touch $FRESH_LOCAL/foobar/file{4,5}
+
+  runFresh
+
+  assertFileMatches <(cd $FRESH_PATH/build && find * -type f | sort) <<EOF
+foo/bar/file1
+foo/bar/file2
+foo/file3
+other/file1
+other/file2
+shell.sh
+EOF
+
+  assertEquals "$(readlink ~/.foo)" "$FRESH_PATH/build/foo"
+  assertEquals "$(readlink ~/.other)" "$FRESH_PATH/build/other"
+  assertTrue 'can traverse symlink' '[ -f ~/.other/file1 ]'
+}
+
 it_builds_bin_files() {
   echo 'fresh scripts/sedmv --bin' >> $FRESH_RCFILE
   echo 'fresh pidof.sh --bin=~/bin/pidof' >> $FRESH_RCFILE


### PR DESCRIPTION
I asked a question on closed issue https://github.com/freshshell/fresh/issues/19#issuecomment-12121921, and having investigated it a bit more, I think it might be a new issue.
Work-round appears to be:

``` bash
fresh mutt/muttrc --file=~/.mutt/muttrc
fresh mutt/colours --file=~/.mutt/colours
```

But I'd prefer to have the whole dir handled in one line (in case I forget to add one of the files)
