### PR TITLE
Relax conditional checking if a symlink already exists

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -301,7 +301,11 @@ _fresh_symlink() {
       ln -s "$SYMLINK_SOURCE" "$SYMLINK_PATH"
     else
       if [[ "$(readlink "$SYMLINK_PATH")" != "$SYMLINK_SOURCE" ]]; then
-        _fatal_error "$SYMLINK_PATH already exists (pointing to $(readlink "$SYMLINK_PATH"))"
+        if [[ "$(readlink "$SYMLINK_PATH")" == "$FRESH_PATH"/build/* ]]; then
+          ln -sf "$SYMLINK_SOURCE" "$SYMLINK_PATH"
+        else
+          _fatal_error "$SYMLINK_PATH already exists (pointing to $(readlink "$SYMLINK_PATH"))"
+        fi
       fi
     fi
   fi

--- a/test/fresh_test.sh
+++ b/test/fresh_test.sh
@@ -621,6 +621,16 @@ it_does_not_error_for_symlinks_created_by_fresh() {
   runFresh # run fresh again to check symlinks
 }
 
+it_replaces_old_symlinks_pointing_inside_the_fresh_build_directory() {
+  echo fresh pryrc --file >> $FRESH_RCFILE
+  mkdir -p $FRESH_PATH/build $FRESH_LOCAL
+  touch $FRESH_LOCAL/pryrc
+  ln -s $FRESH_PATH/build/pryrc-old-name ~/.pryrc
+
+  runFresh
+  assertEquals $FRESH_PATH/build/pryrc "$(readlink ~/.pryrc)"
+}
+
 it_errors_if_link_destination_is_a_file() {
   mkdir -p $FRESH_LOCAL ~/bin
   touch $FRESH_LOCAL/{gitconfig,sedmv}


### PR DESCRIPTION
If a symlink already exists AND it's pointing inside the `~/.fresh/build` directory we can clobber it.

This handles errors caused by a change to how we handle basenames (5e94c91c88b64e66cacc4fe047bb79051d0e0e76).

---

Example error:

```
Error: /Users/odin/.vim/colors/bclear_custom.vim already exists (pointing to /Users/odin/.fresh/build/bclear_custom.vim)
~/.freshrc:40: fresh vim/colors/bclear_custom.vim --file=~/.vim/colors/bclear_custom.vim

You may need to run `fresh update` if you're adding a new line,
or the file you're referencing may have moved or been deleted.
```
