### PR TITLE
Only add ~/bin to PATH once; Fixes bloated subshell/tmux paths on OS X

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -20,7 +20,8 @@ fresh_install() {
   umask 0077
   [ ! -e "$FRESH_PATH/build.new" ] || rm -rf "$FRESH_PATH/build.new"
   mkdir -p "$FRESH_PATH/build.new"
-  echo "export PATH=\"\$HOME/bin:\$PATH\"" >> "$FRESH_PATH/build.new/shell.sh"
+
+  echo "[[ ! \$PATH =~ (^|:)\$HOME/bin(:|\$) ]] && export PATH=\"\$HOME/bin:\$PATH\"" >> "$FRESH_PATH/build.new/shell.sh"
   echo "export FRESH_PATH=\"$FRESH_PATH\"" >> "$FRESH_PATH/build.new/shell.sh"
 
   _run_dsl install


### PR DESCRIPTION
Each time you open a subshell, `$HOME/bin` gets prepended to your path.

``` sh
$ echo $PATH
/Users/ericboehs/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
$ zsh
$ echo $PATH
/Users/ericboehs/bin:/Users/ericboehs/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

This happens when using tmux as tmux preserves the current environment and `PATH` when you open a new tmux session.

This could cause problems if the user wants to override a bin in `$HOME/bin` as this always gets prepended. It also causes odd problems with [direnv](http://direnv.net).

I don't think fresh should duplicitously add `$HOME/bin` to the `PATH`.

Therefore I have made this modification which will only add `$HOME/bin` if it doesn't already exist in the `PATH`. This is based on [this StackOverflow answer](http://superuser.com/a/39995). I have simplified it for our use case.

The resulting `shell.sh` looks like this:

``` sh
[[ ! $PATH =~ (^|:)$HOME/bin(:|$) ]] && export PATH="$HOME/bin:$PATH"
export FRESH_PATH="/Users/ericboehs/.fresh"
```

This is a simple regex which checks to see if `$PATH` contains `$HOME/bin`. If it doesn't then it will add it.

Here's the above example using this patch:

``` sh
$ echo $PATH
/Users/ericboehs/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
$ zsh
$ echo $PATH
/Users/ericboehs/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

_Note_: If your paths are in a different order, that is [due to a bug in OS X](https://github.com/sstephenson/rbenv/issues/369#issuecomment-18408503) but doesn't relate to or affect this PR. If somehow the `$PATH` issue is a problem, I'd recommend an independent PR which would clear the PATH on OS X [similar to this](https://github.com/sstephenson/rbenv/issues/369#issuecomment-33156619)).
