### PR TITLE
Add `fresh file` command

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -955,6 +955,7 @@ clean              # Removes dead symlinks and source repos
 search <query>     # Search the fresh directory
 edit               # Open freshrc for editing
 show               # Show source references for freshrc lines
+file               # Returns the local file path for a fresh line
 help               # Show this help
 EOF
   { for path in ${PATH//:/$'\n'}; do
@@ -964,6 +965,27 @@ EOF
       done
     done
   } | sort | uniq
+}
+
+fresh_file() {
+  if [[ "${1:-}" == "fresh" ]]; then
+    shift
+  fi
+
+  _dsl_fresh_options # init defaults
+  eval _parse_fresh_dsl_args "$@"
+  if [[ -n "$REPO_NAME" ]]; then
+    local REPO_DIR="$FRESH_PATH/source/$(_repo_name "$REPO_NAME")"
+  else
+    local REPO_DIR="$FRESH_LOCAL"
+  fi
+  local FILE="$REPO_DIR/$FILE_NAME"
+
+  if [[ -f "$FILE" ]]; then
+    echo "$FILE"
+  else
+    _fatal_error "File not found: $FILE"
+  fi
 }
 
 main() {
@@ -995,6 +1017,10 @@ main() {
     clean)
       _prevent_invalid_arguments "$@"
       fresh_clean
+      ;;
+    file)
+      shift
+      fresh_file "$@"
       ;;
     commands)
       fresh_commands

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -1848,6 +1848,38 @@ describe 'fresh' do
     end
   end
 
+  describe 'file' do
+    it 'outputs the local file in the source directory' do
+      touch fresh_path + 'source/twe4ked/dotfiles/bin/date-iso'
+
+      run_fresh(
+        command: %w[file twe4ked/dotfiles bin/date-iso --bin=/bin/iso_date],
+        success: "#{fresh_path + 'source/twe4ked/dotfiles/bin/date-iso'}\n")
+    end
+
+    it 'outputs the local file in the source directory when prefixed with fresh' do
+      touch fresh_path + 'source/jasoncodes/dotfiles/bin/vol'
+
+      run_fresh(
+        command: %w[file fresh https://github.com/jasoncodes/dotfiles bin/vol --bin],
+        success: "#{fresh_path + 'source/jasoncodes/dotfiles/bin/vol'}\n")
+    end
+
+    it 'outputs the local file in the local directory' do
+      touch fresh_local_path + 'shell/aliases.sh'
+
+      run_fresh(
+        command: %w[file shell/aliases.sh],
+        success: "#{fresh_local_path + 'shell/aliases.sh'}\n")
+    end
+
+    it 'errors when fresh file output file does not exist' do
+      run_fresh(
+        command: %w[file twe4ked/dotfiles bin/date-iso --bin=/bin/iso_date],
+        error: "#{ERROR_PREFIX} File not found: #{fresh_path + 'source/twe4ked/dotfiles/bin/date-iso'}\n")
+    end
+  end
+
   describe 'fresh-options' do
     it 'applies fresh options to multiple lines' do
       rc <<-EOF


### PR DESCRIPTION
This command returns the local path for a fresh line.

Example:

```
$ fresh file jasoncodes/dotfiles bin/vol --bin
/Users/odin/.fresh/source/jasoncodes/dotfiles/bin/vol
```
