### PR TITLE
Progress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 script: make test
 rvm:
   - 2.1.1
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq bc

--- a/bin/fresh
+++ b/bin/fresh
@@ -95,7 +95,27 @@ _fresh_preamble() {
   fi
 }
 
+__INSTALLED_FRESH_LINES__=0
+if [[ -f "$FRESH_RCFILE" ]]; then
+  __TOTAL_FRESH_LINES__="$(grep "^\s*fresh " "$FRESH_RCFILE" | wc -l | bc)" || true
+else
+  __TOTAL_FRESH_LINES__=0
+fi
+
+_installation_progress() {
+  if [[ "$__TOTAL_FRESH_LINES__" == 0 ]]; then
+    PERCENTAGE=0
+  else
+    PERCENTAGE="$(echo "scale=2; $__INSTALLED_FRESH_LINES__/$__TOTAL_FRESH_LINES__ * 100" | bc)"
+  fi
+  echo -n $'\r'
+  echo -n "$(printf %3.0f "$PERCENTAGE")% complete..."
+}
+
 _dsl_install_fresh() {
+  __INSTALLED_FRESH_LINES__=$((__INSTALLED_FRESH_LINES__ + 1))
+  _installation_progress
+
   _set_dsl_caller
   _parse_fresh_dsl_args "$@"
 

--- a/bin/fresh
+++ b/bin/fresh
@@ -103,6 +103,10 @@ else
 fi
 
 _installation_progress() {
+  if ! [[ -t 0 ]]; then
+    return
+  fi
+
   if [[ "$__TOTAL_FRESH_LINES__" == 0 ]]; then
     PERCENTAGE=0
   else

--- a/bin/fresh
+++ b/bin/fresh
@@ -110,6 +110,9 @@ _installation_progress() {
   fi
   echo -n $'\r'
   echo -n "$(printf %3.0f "$PERCENTAGE")% complete..."
+  if [[ "$PERCENTAGE" = "100.00" ]]; then
+    echo -n $'\r'
+  fi
 }
 
 _dsl_install_fresh() {

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -1132,7 +1132,7 @@ describe 'fresh' do
 
     run_fresh(
       show_progress: true,
-      success: "\r 20% complete...\r 40% complete...\r 60% complete...\r 80% complete...\r100% complete...#{FRESH_SUCCESS_LINE}\n"
+      success: "\r 20% complete...\r 40% complete...\r 60% complete...\r 80% complete...\r100% complete...\r#{FRESH_SUCCESS_LINE}\n"
     )
   end
 

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -1111,6 +1111,31 @@ describe 'fresh' do
     EOF
   end
 
+  it 'shows progress' do
+    rc <<-EOF
+      fresh foobar
+      fresh foobarbaz --bin
+
+      fresh-options --file
+        fresh foo
+        fresh bar
+        fresh baz/foo
+      fresh-options
+
+      fresh_after_build() {
+        true
+      }
+    EOF
+    %w[foobar foobarbaz foo bar baz/foo].each do |path|
+      touch fresh_local_path + path
+    end
+
+    run_fresh(
+      show_progress: true,
+      success: "\r 20% complete...\r 40% complete...\r 60% complete...\r 80% complete...\r100% complete...#{FRESH_SUCCESS_LINE}\n"
+    )
+  end
+
   describe 'update' do
     it 'updates fresh files' do
       FileUtils.mkdir_p fresh_path + 'source/repo/name/.git'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -189,7 +189,7 @@ def format_url(url)
 end
 
 def remove_progress_info(string)
-  string.gsub /\r(\s|\d){3}% complete\.\.\./, ''
+  string.gsub /\r?(\s|\d){3}% complete\.\.\.\r?/, ''
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ def curl_log
 end
 
 def run_fresh(options = {})
-  options.assert_valid_keys :command, :full_command, :exit_status, :success, :error, :error_title
+  options.assert_valid_keys :command, :full_command, :exit_status, :success, :error, :error_title, :show_progress
   @stdout = capture(:stdout) do
     @stderr = capture(:stderr) do
       @exit_status = if options[:full_command]
@@ -60,6 +60,8 @@ def run_fresh(options = {})
       end
     end
   end
+
+  @stdout = remove_progress_info(@stdout) unless options[:show_progress]
 
   if options[:error]
     expect(@stdout).to be_empty
@@ -184,6 +186,10 @@ end
 
 def format_url(url)
   "\033[4;34m#{url}\033[0m"
+end
+
+def remove_progress_info(string)
+  string.gsub /\r(\s|\d){3}% complete\.\.\./, ''
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext/string/strip'
 require 'active_support/core_ext/hash/keys'
 require 'tmpdir'
 require 'pry'
+require 'pty'
 
 ORIGINAL_ENV = ENV.to_hash
 ERROR_PREFIX = "\e[4;31mError\e[0m:"


### PR DESCRIPTION
![fresh-progress](https://cloud.githubusercontent.com/assets/71970/4626699/2ef85138-5384-11e4-95ba-47b555cd2a0d.gif)

Wait for #117 before merging this.

Not sure about the PTY stuff in the test.

This seems to add a bit of time to the total fresh run, perhaps it could be configurable or there may be a more efficient way of doing it. We need benchmarks.
