### PR TITLE
Do a shallow clone of source git repositories

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -175,7 +175,7 @@ EOF
     local REPO_DIR="$FRESH_PATH/source/$(_repo_name "$REPO_NAME")"
     mkdir -p "$(dirname "$REPO_DIR")"
     if ! [ -e "$REPO_DIR" ]; then
-      git clone "$(_repo_url "$REPO_NAME")" "$REPO_DIR"
+      git clone --depth 1 "$(_repo_url "$REPO_NAME")" "$REPO_DIR"
     fi
     SOURCE_DIR="$REPO_DIR"
   else


### PR DESCRIPTION
The performance related to cloning source git repositories has been an issue for me (as I install my dotfiles on virtual machines, and these machines are created and deleted fairly often).

Adding `--depth 1` to the git clone command looks like a fine solution, as the history of the repository isn't used anyways.