### PR TITLE
Deal with file names that have special characters

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -284,9 +284,13 @@ _source_file_contents() {
   if [[ -n "$REF" ]]; then
     cd "$SOURCE_DIR"
     if [[ -n "$FILTER" ]]; then
-      git show "$REF:$SOURCE_FILE" | eval "$FILTER"
+      # Deal with special characters in source file name
+      local escape_string=$(echo $SOURCE_FILE | sed -e 's/^"//' -e 's/"$//' | sed -e 's/\$/\\$/g' -e 's/"/\\"/g')
+      eval "git show $REF:\"$escape_string\"" | eval "$FILTER"
     else
-      git show "$REF:$SOURCE_FILE"
+      # Deal with special characters in source file name
+      local escape_string=$(echo $SOURCE_FILE | sed -e 's/^"//' -e 's/"$//' | sed -e 's/\$/\\$/g' -e 's/"/\\"/g')
+      eval "git show $REF:\"$escape_string\""
     fi
     cd "$OLDPWD"
   else


### PR DESCRIPTION
Having a `"` (double quote) or `$` (dollar) character in the file name
in a git repo of a fresh source breaks when using the `--ref` flag. Work
around is to strip the double quotes from the string ends then escape
the `$` and `"` characters.

[issue/135](https://github.com/freshshell/fresh/issues/135)
