### PR TITLE
Make `_fresh_preamble` POSIX-compliant

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -88,7 +88,14 @@ fresh_after_build() {
 _fresh_preamble() {
   if [ -z "${__FRESH_PREAMBLE_DONE__:-}" ]; then
     if [ -z "${FRESH_NO_PATH_EXPORT:-}" ]; then
-      echo "__FRESH_BIN_PATH__="${FRESH_BIN_PATH/#$HOME/\$HOME}"; [[ ! \$PATH =~ (^|:)\$__FRESH_BIN_PATH__(:|\$) ]] && export PATH=\"\$__FRESH_BIN_PATH__:\$PATH\"; unset __FRESH_BIN_PATH__" >> "$FRESH_PATH/build.new/shell.sh"
+      cat <<EOF >> "$FRESH_PATH/build.new/shell.sh"
+__FRESH_BIN_PATH__=${FRESH_BIN_PATH/#$HOME/\$HOME}
+case ":\$PATH:" in
+*:\$__FRESH_BIN_PATH__:*) : ;;
+*) export PATH="\$__FRESH_BIN_PATH__:\$PATH" ;;
+esac
+unset __FRESH_BIN_PATH__
+EOF
     fi
     echo "export FRESH_PATH=\"$FRESH_PATH\"" >> "$FRESH_PATH/build.new/shell.sh"
     __FRESH_PREAMBLE_DONE__=1

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -1462,7 +1462,12 @@ SH
         expect(File.read(fresh_bin_path)).to eq "test file\n"
         expect_readlink(fresh_bin_path).to eq (fresh_path + 'build/bin/fresh').to_s
         expect(File.read(shell_sh_path)).to eq <<-EOF.strip_heredoc
-          __FRESH_BIN_PATH__=$HOME/Applications/bin; [[ ! $PATH =~ (^|:)$__FRESH_BIN_PATH__(:|$) ]] && export PATH="$__FRESH_BIN_PATH__:$PATH"; unset __FRESH_BIN_PATH__
+          __FRESH_BIN_PATH__=$HOME/Applications/bin
+          case ":$PATH:" in
+          *:$__FRESH_BIN_PATH__:*) : ;;
+          *) export PATH="$__FRESH_BIN_PATH__:$PATH" ;;
+          esac
+          unset __FRESH_BIN_PATH__
           export FRESH_PATH="#{fresh_path}"
         EOF
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -161,15 +161,20 @@ def expect_shell_sh
   expect(shell_sh_path).to_not be_executable
 
   empty_shell_sh = <<-EOF.strip_heredoc
-    __FRESH_BIN_PATH__=$HOME/bin; [[ ! $PATH =~ (^|:)$__FRESH_BIN_PATH__(:|$) ]] && export PATH="$__FRESH_BIN_PATH__:$PATH"; unset __FRESH_BIN_PATH__
+    __FRESH_BIN_PATH__=$HOME/bin
+    case ":$PATH:" in
+    *:$__FRESH_BIN_PATH__:*) : ;;
+    *) export PATH="$__FRESH_BIN_PATH__:$PATH" ;;
+    esac
+    unset __FRESH_BIN_PATH__
     export FRESH_PATH="#{fresh_path}"
   EOF
 
   shell_sh_content_lines = File.read(shell_sh_path).lines
 
-  expect(shell_sh_content_lines[0..1].join).to eq empty_shell_sh
+  expect(shell_sh_content_lines[0..6].join).to eq empty_shell_sh
 
-  content = shell_sh_content_lines[3..-1] || []
+  content = shell_sh_content_lines[8..-1] || []
   expect(content.join)
 end
 


### PR DESCRIPTION
POSIX doesn't support bash features like `[[` and `=~`.  Rewrite the function with POSIX-compliant syntax.
