### PR TITLE
Use /usr/bin/env bash -e instead of /bin/bash

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 FRESH_RCFILE="${FRESH_RCFILE:-$HOME/.freshrc}"
 FRESH_PATH="${FRESH_PATH:-$HOME/.fresh}"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Install fresh with the following command:
 #

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -1426,7 +1426,7 @@ describe 'fresh' do
       let(:path) do
         capture(:stdout) do
           system <<-EOF
-/bin/bash -c "$(
+/usr/bin/env bash -c "$(
 cat <<'SH'
   export PATH=/usr/bin
   source #{shell_sh_path}
@@ -1477,7 +1477,7 @@ SH
 
         path = capture(:stdout) do
           system <<-EOF
-/bin/bash -c "$(
+/usr/bin/env bash -c "$(
 cat <<'SH'
   export PATH=/usr/bin
   source #{shell_sh_path}
@@ -1498,7 +1498,7 @@ SH
         run_fresh
         out = capture(:stdout) do
           system <<-EOF
-/bin/bash -c "$(
+/usr/bin/env bash -c "$(
 cat <<'SH'
   source #{shell_sh_path}
   echo "$__FRESH_BIN_PATH__"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,7 +127,8 @@ def stub_curl(*args)
   options.assert_valid_keys :error
 
   template = <<-ERB.strip_heredoc
-    #!/bin/bash -e
+    #!/usr/bin/env bash
+    set -e
 
     echo curl >> <%= curl_log_path %>
 

--- a/spec/support/bin/git
+++ b/spec/support/bin/git
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 echo cd "$(pwd)" >> $SANDBOX_PATH/git.log
 echo git "$@" >> $SANDBOX_PATH/git.log


### PR DESCRIPTION
I'm using fresh to bootstrap my [NixOS](https://nixos.org/) machines like you suggest in the wiki `FRESH_LOCAL_SOURCE=mycool/repo bash <(curl -sL https://get.freshshell.com)`, but it fails on `/bin/bash` not existing.

NixOS doesn't have `/bin/bash` because of the way dependencies are handled / linked:
```
$ which bash
/run/current-system/sw/bin/bash
```
Using `/usr/bin/env` in the shebang seems to work on OSX and NixOS.