### PR TITLE
make fresh clean respect FRESH_BIN_PATH

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -1074,7 +1074,7 @@ sub fresh_clean_repos {
 
 sub fresh_clean {
   fresh_clean_symlinks($ENV{HOME});
-  fresh_clean_symlinks("$ENV{HOME}/bin");
+  fresh_clean_symlinks($FRESH_BIN_PATH);
   fresh_clean_repos;
 }
 


### PR DESCRIPTION
The FRESH_BIN_PATH env var is much appreciated to allow bin dirs other than $HOME/bin, however, $HOME/bin is hard-coded in fresh_clean sub. Please consider this revision to use previously resolved $FRESH_BIN_PATH.