### PR TITLE
Change file pattern to ".git" to detect git depot

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -947,7 +947,7 @@ EOF
   if (-d "$FRESH_PATH/source") {
     my @paths;
     my $wanted = sub {
-      /\.git\z/ && push @paths, dirname($_);
+      /\/\.git\z/ && push @paths, dirname($_);
     };
     find({wanted => $wanted, no_chdir => 1}, "$FRESH_PATH/source");
     @paths = sort @paths;

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -1233,6 +1233,26 @@ describe 'fresh' do
       EOF
     end
 
+    it 'updates fresh files, but ignore files ending with .git' do
+      FileUtils.mkdir_p fresh_path + 'source/repo/name/.git'
+      FileUtils.mkdir_p fresh_path + 'source/repo/name/subdir'
+      touch fresh_path + 'source/repo/name/subdir/filea.git'
+      touch fresh_path + 'source/repo/name/subdir/fileb.git'
+      touch fresh_path + 'source/repo/name/subdir/filec.git'
+      stub_git
+
+      run_fresh command: 'update', success: <<-EOF.strip_heredoc
+        * Updating repo/name
+        | Current branch master is up to date.
+        #{FRESH_SUCCESS_LINE}
+      EOF
+
+      expect(git_log).to eq <<-EOF.strip_heredoc
+        cd #{fresh_path + 'source/repo/name'}
+        git pull --rebase
+      EOF
+    end
+
     it 'updates fresh files for a specified GitHub user' do
       FileUtils.mkdir_p fresh_path + 'source/twe4ked/dotfiles/.git'
       FileUtils.mkdir_p fresh_path + 'source/twe4ked/scripts/.git'

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -460,6 +460,7 @@ describe 'fresh' do
     describe 'cloning' do
       it 'clones GitHub repos' do
         rc 'fresh repo/name file'
+        rc 'fresh other_repo/other_name.git file'
         stub_git
 
         run_fresh
@@ -467,6 +468,8 @@ describe 'fresh' do
         expect(git_log).to eq <<-EOF.strip_heredoc
           cd #{Dir.pwd}
           git clone https://github.com/repo/name #{sandbox_path}/fresh/source/repo/name
+          cd #{Dir.pwd}
+          git clone https://github.com/other_repo/other_name.git #{sandbox_path}/fresh/source/other_repo/other_name.git
         EOF
         expect(
           File.read sandbox_path + 'fresh/source/repo/name/file'
@@ -1215,9 +1218,12 @@ describe 'fresh' do
     it 'updates fresh files' do
       FileUtils.mkdir_p fresh_path + 'source/repo/name/.git'
       FileUtils.mkdir_p fresh_path + 'source/other_repo/other_name/.git'
+      FileUtils.mkdir_p fresh_path + 'source/further_repo/further_name.git/.git'
       stub_git
 
       run_fresh command: 'update', success: <<-EOF.strip_heredoc
+        * Updating further_repo/further_name.git
+        | Current branch master is up to date.
         * Updating other_repo/other_name
         | Current branch master is up to date.
         * Updating repo/name
@@ -1226,6 +1232,8 @@ describe 'fresh' do
       EOF
 
       expect(git_log).to eq <<-EOF.strip_heredoc
+        cd #{fresh_path + 'source/further_repo/further_name.git'}
+        git pull --rebase
         cd #{fresh_path + 'source/other_repo/other_name'}
         git pull --rebase
         cd #{fresh_path + 'source/repo/name'}


### PR DESCRIPTION
This change fixes the issue #161 and also enables the usage of github `name/repo.git `.