### PR TITLE
FreeBSD 12.1 fix

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -280,12 +280,13 @@ sub print_and_append {
 
 sub readfile {
   my ($filename) = @_;
-  if (open(my $fh, $filename)) {
+  if ((-f $filename) && (open(my $fh, $filename))) {
     local $/ = undef;
     my $data = <$fh>;
     close $fh;
     return $data;
   }
+  return undef;
 }
 
 sub read_file_line {


### PR DESCRIPTION
Hello mate!

I think this is easier to explain with a real example:

```
# uname -a
Linux 715d52d308b7 4.19.76-linuxkit #1 SMP Thu Oct 17 19:31:58 UTC 2019 x86_64 GNU/Linux
[root:~] # mkdir test
[root:~] # cat test
cat: test: Is a directory
```

```
$ uname -a
FreeBSD animal.local 12.1-RELEASE-p3 FreeBSD 12.1-RELEASE-p3 GENERIC  amd64
$ mkdir test
$ cat test
O&
```

the perl diamond operator `<>` returns `undef` when you try to read an  opened directory from the file-handled in Linux, but the directories are files in UNIX (FreeBSD in this case) and they are never `undef` 

The `if (defined $data)` is always true in FreeBSD and that's breaking the compatibility.
This is my approach to solve it. I'm not a developer.

Working in my Linux and my FreeBSD with this fix as far as i could test it in bash!
