### PR TITLE
Check .fresh-order file before call 'git show'

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -623,9 +623,12 @@ sub get_entry_paths {
   my $full_entry_name = "$prefix$$entry{name}";
   my $base_entry_name = dirname($full_entry_name);
 
+  my $fresh_order_file_exists = 0;
+
   if ($$entry{options}{ref}) {
     $base_entry_name = dirname($$entry{name});
     @paths = split(/\n/, read_cwd_cmd($prefix, 'git', 'ls-tree', '-r', '--name-only', $$entry{options}{ref}));
+    $fresh_order_file_exists = grep {$_ eq $base_entry_name."/.fresh-order";} @paths;
     if ($is_dir_target) {
       if ($$entry{name} ne ".") {
         @paths = prefix_filter("$$entry{name}/", @paths);
@@ -652,7 +655,11 @@ sub get_entry_paths {
   if ($$entry{options}{ref}) {
     if ($$entry{name} =~ /\*/) {
       my $dir = dirname($$entry{name});
-      $fresh_order_data = read_cwd_cmd($prefix, 'git', 'show', "$$entry{options}{ref}:$dir/.fresh-order");
+
+      if ($fresh_order_file_exists)
+      {
+        $fresh_order_data = read_cwd_cmd($prefix, 'git', 'show', "$$entry{options}{ref}:$dir/.fresh-order");
+      }
     }
   } else {
     $fresh_order_data = readfile($base_entry_name . '/.fresh-order');

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -623,8 +623,6 @@ describe 'fresh' do
           cd #{fresh_path + 'source/repo/name'}
           git ls-tree -r --name-only abc1237
           cd #{fresh_path + 'source/repo/name'}
-          git show abc1237:aliases/.fresh-order
-          cd #{fresh_path + 'source/repo/name'}
           git show abc1237:aliases/git.sh
           cd #{fresh_path + 'source/repo/name'}
           git show abc1237:aliases/ruby.sh

--- a/spec/support/bin/git
+++ b/spec/support/bin/git
@@ -27,6 +27,9 @@ case "$1" in
       echo d
       echo f
       echo b
+    elif [[ "$2" == "abc1237:aliases/.fresh-order" ]]; then
+        echo "fatal: Path 'aliases/.fresh-order' does not exist in 'abc1237'"
+        exit 128
     else
       echo test data for "$2"
     fi


### PR DESCRIPTION
git show returns with exit code 128, in case of non-existing file.

This change checks if the .fresh-order is part of the directory
and only if the file is present the git show command will be invoked.

Issue: https://github.com/freshshell/fresh/issues/137