### PR TITLE
Fix `--ref` globbing when no `.fresh-order` exists

### DIFF
--- a/bin/fresh
+++ b/bin/fresh
@@ -653,7 +653,10 @@ sub get_entry_paths {
   if ($$entry{options}{ref}) {
     if ($$entry{name} =~ /\*/) {
       my $dir = dirname($$entry{name});
-      $fresh_order_data = read_cwd_cmd($prefix, 'git', 'show', "$$entry{options}{ref}:$dir/.fresh-order");
+      my $fresh_order_exists = length(read_cwd_cmd($prefix, 'git', 'ls-tree', '--name-only', $$entry{options}{ref}, "$dir/.fresh-order"));
+      if ($fresh_order_exists) {
+        $fresh_order_data = read_cwd_cmd($prefix, 'git', 'show', "$$entry{options}{ref}:$dir/.fresh-order");
+      }
     }
   } else {
     $fresh_order_data = readfile($base_entry_name . '/.fresh-order');

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -348,7 +348,7 @@ describe 'fresh' do
           end
         end
 
-        it 'builds with ref' do
+        it 'builds with --ref' do
           rc 'fresh repo/name recursive-test --ref=abc1237 --file=vendor/test/'
           FileUtils.mkdir_p fresh_path + 'source/repo/name'
           stub_git
@@ -654,7 +654,7 @@ describe 'fresh' do
           to eq "test data for abcdefg:sedmv\n"
       end
 
-      it 'errors if source file missing at ref' do
+      it 'errors if source file missing at --ref' do
         rc 'fresh repo/name bad-file --ref=abc1237'
         FileUtils.mkdir_p fresh_path + 'source/repo/name'
         stub_git
@@ -675,7 +675,7 @@ describe 'fresh' do
       end
 
       context 'with --ignore-missing' do
-        it 'does not error if source file missing at ref with --ignore-missing' do
+        it 'does not error if source file missing at --ref with --ignore-missing' do
           rc 'fresh repo/name bad-file --ref=abc1237 --ignore-missing'
           FileUtils.mkdir_p fresh_path + 'source/repo/name'
           stub_git
@@ -688,7 +688,7 @@ describe 'fresh' do
           EOF
         end
 
-        it 'builds files with ref and ignore missing' do
+        it 'builds files with --ref and --ignore-missing' do
           rc <<-EOF.strip_heredoc
             fresh repo/name ackrc --file --ref=abc1237 --ignore-missing
             fresh repo/name missing --file --ref=abc1237 --ignore-missing
@@ -711,7 +711,7 @@ describe 'fresh' do
         end
       end
 
-      it 'errors if no ref is specified' do
+      it 'errors if no --ref value is specified' do
         rc 'fresh foo --file --ref'
 
         run_fresh error: <<-EOF.strip_heredoc
@@ -752,7 +752,7 @@ describe 'fresh' do
         expect_pathname('~/.foo/sub/file2').to exist
       end
 
-      it 'links directory of generic files for whole repo with ref' do
+      it 'links directory of generic files for whole repo with --ref' do
         rc 'fresh repo/name . --file=~/.foo/ --ref=abc123'
 
         run_fresh
@@ -821,7 +821,7 @@ describe 'fresh' do
       EOF
     end
 
-    it 'with ref' do
+    it 'with --ref' do
       rc "fresh repo/name 'recursive-test/*' --ref=abc1237"
       stub_git
 
@@ -863,7 +863,7 @@ describe 'fresh' do
       end
     end
 
-    context 'with ref' do
+    context 'with --ref' do
       before do
         stub_git
       end
@@ -878,7 +878,7 @@ describe 'fresh' do
         EOF
       end
 
-      it 'includes hidden files when explicitly referenced with ref' do
+      it 'includes hidden files when explicitly referenced with --ref' do
         rc "fresh repo/name 'hidden-test/.*' --ref=abc1237"
 
         run_fresh
@@ -913,7 +913,7 @@ describe 'fresh' do
       EOF
     end
 
-    it 'with ref' do
+    it 'with --ref' do
       rc "fresh repo/name 'order-test/*' --ref=abc1237"
       FileUtils.mkdir_p fresh_path + 'source/repo/name'
       stub_git
@@ -963,7 +963,7 @@ describe 'fresh' do
       EOF
     end
 
-    it 'runs filters on files locked to a ref' do
+    it 'runs filters on files locked to a --ref' do
       FileUtils.mkdir_p fresh_local_path
       rc "fresh aliases/git.sh --ref=abc1237 --filter='sed s/test/TEST/'"
       stub_git

--- a/spec/fresh_spec.rb
+++ b/spec/fresh_spec.rb
@@ -623,7 +623,7 @@ describe 'fresh' do
           cd #{fresh_path + 'source/repo/name'}
           git ls-tree -r --name-only abc1237
           cd #{fresh_path + 'source/repo/name'}
-          git show abc1237:aliases/.fresh-order
+          git ls-tree --name-only abc1237 aliases/.fresh-order
           cd #{fresh_path + 'source/repo/name'}
           git show abc1237:aliases/git.sh
           cd #{fresh_path + 'source/repo/name'}
@@ -931,6 +931,8 @@ describe 'fresh' do
       expect(git_log).to eq <<-EOF.strip_heredoc
         cd #{fresh_path + 'source/repo/name'}
         git ls-tree -r --name-only abc1237
+        cd #{fresh_path + 'source/repo/name'}
+        git ls-tree --name-only abc1237 order-test/.fresh-order
         cd #{fresh_path + 'source/repo/name'}
         git show abc1237:order-test/.fresh-order
         cd #{fresh_path + 'source/repo/name'}

--- a/spec/support/bin/git
+++ b/spec/support/bin/git
@@ -29,9 +29,20 @@ case "$1" in
       echo b
       exit 0
     fi
+    if [[ "$2" == "abc1237:aliases/.fresh-order" ]]; then
+      echo "fatal: Path 'aliases/.fresh-order' does not exist in 'abc1237'" >&2
+      exit 128
+    fi
     echo test data for "$2"
     ;;
   ls-tree)
+    if [[ "$*" =~ ^ls-tree\ --name-only\ abc1237\ (aliases|recursive-test)/\.fresh-order$ ]]; then
+      exit 0
+    fi
+    if [[ "$*" =~ ^ls-tree\ --name-only\ abc1237\ (hidden-test|order-test)/\.fresh-order$ ]]; then
+      echo "$4"
+      exit 0
+    fi
     if [[ "$*" =~ ^ls-tree\ -r\ --name-only\ (abc1237|1234567|abcdefg|abc123)$ ]]; then
       echo aliases/git.sh
       echo aliases/ruby.sh

--- a/spec/support/bin/git
+++ b/spec/support/bin/git
@@ -33,7 +33,31 @@ case "$1" in
       echo "fatal: Path 'aliases/.fresh-order' does not exist in 'abc1237'" >&2
       exit 128
     fi
-    echo test data for "$2"
+    if [[ "$*" =~ ^show\ abc1237?:(aliases/git\.sh|aliases/ruby\.sh|ackrc|sedmv)$ ]]; then
+      echo test data for "$2"
+      exit 0
+    fi
+    if [[ "$*" =~ ^show\ (1234567:ackrc|abcdefg:sedmv)$ ]]; then
+      echo test data for "$2"
+      exit 0
+    fi
+    if [[ "$*" =~ ^show\ abc1237?:recursive-test/(foo|bar|abc/def)$ ]]; then
+      echo test data for "$2"
+      exit 0
+    fi
+    if [[ "$*" =~ ^show\ abc123:recursive-test-other/abc/def$ ]]; then
+      echo test data for "$2"
+      exit 0
+    fi
+    if [[ "$*" =~ ^show\ abc1237?:hidden-test/(\.fresh-order|foo|\.bar)$ ]]; then
+      echo test data for "$2"
+      exit 0
+    fi
+    if [[ "$*" =~ ^show\ abc1237?:order-test/(\.fresh-order|[abcde])$ ]]; then
+      echo test data for "$2"
+      exit 0
+    fi
+    echo "unknown git args: $*" >&2
     ;;
   ls-tree)
     if [[ "$*" =~ ^ls-tree\ --name-only\ abc1237\ (aliases|recursive-test)/\.fresh-order$ ]]; then

--- a/spec/support/bin/git
+++ b/spec/support/bin/git
@@ -32,23 +32,28 @@ case "$1" in
     echo test data for "$2"
     ;;
   ls-tree)
-    echo aliases/git.sh
-    echo aliases/ruby.sh
-    echo ackrc
-    echo sedmv
-    echo recursive-test/foo
-    echo recursive-test/bar
-    echo recursive-test/abc/def
-    echo recursive-test-other/abc/def
-    echo hidden-test/foo
-    echo hidden-test/.bar
-    echo hidden-test/.fresh-order
-    echo order-test/.fresh-order
-    echo order-test/a
-    echo order-test/b
-    echo order-test/c
-    echo order-test/d
-    echo order-test/e
+    if [[ "$*" =~ ^ls-tree\ -r\ --name-only\ (abc1237|1234567|abcdefg|abc123)$ ]]; then
+      echo aliases/git.sh
+      echo aliases/ruby.sh
+      echo ackrc
+      echo sedmv
+      echo recursive-test/foo
+      echo recursive-test/bar
+      echo recursive-test/abc/def
+      echo recursive-test-other/abc/def
+      echo hidden-test/foo
+      echo hidden-test/.bar
+      echo hidden-test/.fresh-order
+      echo order-test/.fresh-order
+      echo order-test/a
+      echo order-test/b
+      echo order-test/c
+      echo order-test/d
+      echo order-test/e
+      exit 0
+    fi
+    echo "unknown git args: $*" >&2
+    exit 1
     ;;
   log)
     echo 1234567

--- a/spec/support/bin/git
+++ b/spec/support/bin/git
@@ -27,9 +27,9 @@ case "$1" in
       echo d
       echo f
       echo b
-    else
-      echo test data for "$2"
+      exit 0
     fi
+    echo test data for "$2"
     ;;
   ls-tree)
     echo aliases/git.sh


### PR DESCRIPTION
Fixes #137